### PR TITLE
fix DOAP syntax

### DIFF
--- a/content/doap_Olingo.rdf
+++ b/content/doap_Olingo.rdf
@@ -45,26 +45,36 @@ The extensions part of Olingo for OData 2.0 contains additional features like th
         <created>2023-12-18</created>
         <revision>5.0.0</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>OData 4.0 Library for Java</name>
         <created>2023-10-22</created>
         <revision>4.10.0</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>OData 4.0 Library for Java</name>
         <created>2022-03-09</created>
         <revision>4.9.0</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>OData 4.0 Library for Java</name>
         <created>2020-12-27</created>
         <revision>4.8.0</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>OData 4.0 Library for Java</name>
         <created>2019-12-25</created>
         <revision>4.7.1</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>OData 4.0 Library for Java</name>
         <created>2019-12-04</created>


### PR DESCRIPTION
I'm having some trouble finding an authoritative reference, but it looks like a release (which is a property) may not contain multiple Versions (which is a node) in RDF/XML. The python rdflib at least doesn't support it, and whatever generates https://projects.apache.org/json/projects/olingo.json and https://projects.apache.org/project.html?olingo also doesn't seem to process it correctly.